### PR TITLE
Add a helper method to retrieve the list of variants

### DIFF
--- a/test/adt_test.exs
+++ b/test/adt_test.exs
@@ -6,6 +6,10 @@ defmodule AdtTest do
     ADT.define foo(a: 0) | bar(val: "hey")
   end
 
+  defmodule AdtDefinitionThree do
+    ADT.define foo(a: 0) | bar(val: "hey") | baz
+  end
+
   defmodule AdtWithVariantWithoutFields do
     ADT.define foo(a: 0) | bar
   end
@@ -43,5 +47,10 @@ defmodule AdtTest do
     catch_error(Code.compile_quoted do
       ADT.define
     end)
+  end
+
+  test "getting variants from the Module" do
+    assert AdtDefinition.variants == [AdtTest.AdtDefinition.Bar, AdtTest.AdtDefinition.Foo]
+    assert AdtDefinitionThree.variants == [AdtTest.AdtDefinitionThree.Baz, AdtTest.AdtDefinitionThree.Bar, AdtTest.AdtDefinitionThree.Foo]
   end
 end


### PR DESCRIPTION
Stores the variants in an accumulator called `@variants`. Adds a helper method to the module to retrieve this value.

I think this will make adding an exhaustive case macro easier, as we'll be able to access the list of variants that should be accounted for.
