### PR TITLE
start working on the exhaustivity checker

### DIFF
--- a/test/adt_test.exs
+++ b/test/adt_test.exs
@@ -61,4 +61,12 @@ defmodule AdtTest do
       _ -> false
     end)
   end
+
+  test "adtcase allows per-module pattern matching" do
+    foo = %AdtDefinition.Foo{}
+    assert 0 == (ADT.case AdtDefinition, foo do
+      %AdtDefinition.Foo{a: a} -> a
+      _ -> false
+    end)
+  end
 end


### PR DESCRIPTION
Resolves #1.

I really don't like this style. I wish we could scala-style and write stuff like `q"def $name(...)" = $part"` for neater AST pattern matching. This'll have to do for now, I guess.

I'm able to collect the names. The result (debug is still in ATM) looks like this:

```
[:_, [:AdtDefinition, :Foo]]
```

The presence of `_` must be detected (we could even stop the `Enum.reduce`) to never trigger warnings.
