### PR TITLE
Working WIP exhaustive case macro

### DIFF
--- a/lib/adt.ex
+++ b/lib/adt.ex
@@ -41,11 +41,8 @@ defmodule ADT do
           raise ADT._exhaustive_error(possible_variants, given_variant_names)
         end
         rules = Enum.flat_map(given_variants, fn {k, v} ->
-          condition = quote do
-            unquote(k) == ADT._shorten(unquote(a))
-          end
           quote do
-            unquote(condition) -> unquote(v).(unquote(a))
+            unquote(k) == ADT._shorten(unquote(a)) -> unquote(v).(unquote(a))
           end
         end)
         quote do
@@ -57,7 +54,7 @@ defmodule ADT do
 
   # Maps a module like Foo.Bar.Baz into a short string "Baz"
   def _shorten(name) do
-    Regex.named_captures(~r/\.(?<short>[^\.{]+)($|{)/, inspect(name), include_captures: true) |> Map.fetch!("short")
+    Regex.named_captures(~r/.(?<short>[^.{]+)($|{)/, inspect(name), include_captures: true) |> Map.fetch!("short")
   end
 
   def _exhaustive_error(possible_variants, given_variants) do

--- a/lib/adt.ex
+++ b/lib/adt.ex
@@ -54,7 +54,7 @@ defmodule ADT do
 
   # Maps a module like Foo.Bar.Baz into a short string "Baz"
   def _shorten(name) do
-    Regex.named_captures(~r/.(?<short>[^.{]+)($|{)/, inspect(name), include_captures: true) |> Map.fetch!("short")
+    Regex.named_captures(~r/\.(?<short>[^.{]+)($|{)/, inspect(name), include_captures: true) |> Map.fetch!("short")
   end
 
   def _exhaustive_error(possible_variants, given_variants) do

--- a/lib/adt.ex
+++ b/lib/adt.ex
@@ -32,7 +32,7 @@ defmodule ADT do
       defmacro case(a, statements) do
         possible_variants = unquote(values) |> Enum.map(
           fn {variant, _} ->
-            ADT._shorten_module_name(variant)
+            ADT._shorten(variant)
           end
         ) |> Enum.sort
         given_variants = statements |> Enum.map(fn {k, v} -> { to_string(k), v } end) |> Enum.sort
@@ -42,7 +42,7 @@ defmodule ADT do
         end
         rules = Enum.flat_map(given_variants, fn {k, v} ->
           condition = quote do
-            unquote(k) == ADT._shorten_match(unquote(a))
+            unquote(k) == ADT._shorten(unquote(a))
           end
           quote do
             unquote(condition) -> unquote(v).(unquote(a))
@@ -56,12 +56,8 @@ defmodule ADT do
   end
 
   # Maps a module like Foo.Bar.Baz into a short string "Baz"
-  def _shorten_module_name(variant) do
-    Regex.named_captures(~r/\.(?<short>[^\.]+)$/, inspect(variant), include_captures: true) |> Map.fetch!("short")
-  end
-
-  def _shorten_match(match) do
-    Regex.named_captures(~r/\.(?<short>[^\.]+){/, inspect(match), include_captures: true) |> Map.fetch!("short")
+  def _shorten(name) do
+    Regex.named_captures(~r/\.(?<short>[^\.{]+)($|{)/, inspect(name), include_captures: true) |> Map.fetch!("short")
   end
 
   def _exhaustive_error(possible_variants, given_variants) do

--- a/lib/adt.ex
+++ b/lib/adt.ex
@@ -38,7 +38,7 @@ defmodule ADT do
         given_variants = statements |> Enum.map(fn {k, v} -> { to_string(k), v } end) |> Enum.sort
         given_variant_names = given_variants |> Enum.map(fn {k, _} -> k end)
         if possible_variants != given_variant_names do
-          raise "Not exhaustive!"
+          raise ADT._exhaustive_error(possible_variants, given_variant_names)
         end
         rules = Enum.flat_map(given_variants, fn {k, v} ->
           condition = quote do
@@ -62,6 +62,10 @@ defmodule ADT do
 
   def _shorten_match(match) do
     Regex.named_captures(~r/\.(?<short>[^\.]+){/, inspect(match), include_captures: true) |> Map.fetch!("short")
+  end
+
+  def _exhaustive_error(possible_variants, given_variants) do
+    "case macro not exhaustive.\nGiven #{inspect(given_variants)}.\nPossible: #{inspect(possible_variants)}."
   end
 
   # Flatten "one | two | three" ("one | (two | three)" in the AST

--- a/test/adt_test.exs
+++ b/test/adt_test.exs
@@ -54,6 +54,20 @@ defmodule AdtTest do
     assert AdtDefinitionThree.variants == [AdtTest.AdtDefinitionThree.Baz, AdtTest.AdtDefinitionThree.Bar, AdtTest.AdtDefinitionThree.Foo]
   end
 
+  test "case" do
+    require AdtTest.AdtDefinition
+
+    foo = %AdtDefinition.Foo{}
+
+    result = AdtDefinition.case foo do
+      [
+        {"Foo", fn(x) -> "foo" end},
+        {"Bar", fn(x) -> "bar" end}
+      ]
+    end
+    assert result == "foo"
+  end
+
   test "you can pattern match an ADT" do
     foo = %AdtDefinition.Foo{}
     assert 0 == (case foo do

--- a/test/adt_test.exs
+++ b/test/adt_test.exs
@@ -59,24 +59,20 @@ defmodule AdtTest do
 
     foo = %AdtDefinition.Foo{}
 
-    result = AdtDefinition.case foo do
-      [
-        {"Foo", fn(x) -> "foo" end},
-        {"Bar", fn(x) -> "bar" end}
-      ]
-    end
-    assert result == "foo"
+    result = AdtDefinition.case foo, [
+      Foo: fn(x) -> "1" end,
+      Bar: fn(x) -> "2" end
+    ]
+    assert result == "1"
   end
 
   test "non-exhaustive case" do
     catch_error Code.eval_string """
       require AdtTest.AdtDefinition
 
-      result = AdtTest.AdtDefinition.case %AdtTest.AdtDefinition.Foo{} do
-        [
-          {"Foo", fn(x) -> "foo" end}
-        ]
-      end
+      result = AdtTest.AdtDefinition.case %AdtTest.AdtDefinition.Foo{}, [
+        Foo: fn(x) -> "foo" end
+      ]
     """
   end
 

--- a/test/adt_test.exs
+++ b/test/adt_test.exs
@@ -68,6 +68,18 @@ defmodule AdtTest do
     assert result == "foo"
   end
 
+  test "non-exhaustive case" do
+    catch_error Code.eval_string """
+      require AdtTest.AdtDefinition
+
+      result = AdtTest.AdtDefinition.case %AdtTest.AdtDefinition.Foo{} do
+        [
+          {"Foo", fn(x) -> "foo" end}
+        ]
+      end
+    """
+  end
+
   test "you can pattern match an ADT" do
     foo = %AdtDefinition.Foo{}
     assert 0 == (case foo do

--- a/test/adt_test.exs
+++ b/test/adt_test.exs
@@ -67,13 +67,14 @@ defmodule AdtTest do
   end
 
   test "non-exhaustive case" do
-    catch_error Code.eval_string """
+    error = catch_error Code.eval_string """
       require AdtTest.AdtDefinition
 
       result = AdtTest.AdtDefinition.case %AdtTest.AdtDefinition.Foo{}, [
         Foo: fn(x) -> "foo" end
       ]
     """
+    assert error.message == "case macro not exhaustive.\nGiven [\"Foo\"].\nPossible: [\"Bar\", \"Foo\"]."
   end
 
   test "you can pattern match an ADT" do

--- a/test/adt_test.exs
+++ b/test/adt_test.exs
@@ -60,8 +60,8 @@ defmodule AdtTest do
     foo = %AdtDefinition.Foo{}
 
     result = AdtDefinition.case foo, [
-      Foo: fn(x) -> "1" end,
-      Bar: fn(x) -> "2" end
+      Foo: fn(_) -> "1" end,
+      Bar: fn(_) -> "2" end
     ]
     assert result == "1"
   end

--- a/test/adt_test.exs
+++ b/test/adt_test.exs
@@ -77,6 +77,19 @@ defmodule AdtTest do
     assert error.message == "case macro not exhaustive.\nGiven [\"Foo\"].\nPossible: [\"Bar\", \"Foo\"]."
   end
 
+  test "dead code in case statement" do
+    error = catch_error Code.eval_string """
+      require AdtTest.AdtDefinition
+
+      result = AdtTest.AdtDefinition.case %AdtTest.AdtDefinition.Foo{}, [
+        Foo: fn(x) -> "1" end,
+        Bar: fn(x) -> "2" end,
+        Baz: fn(x) -> "3" end
+      ]
+    """
+    assert error.message == "case macro not exhaustive.\nGiven [\"Bar\", \"Baz\", \"Foo\"].\nPossible: [\"Bar\", \"Foo\"]."
+  end
+
   test "you can pattern match an ADT" do
     foo = %AdtDefinition.Foo{}
     assert 0 == (case foo do


### PR DESCRIPTION
The following macro won't even expand in the test!

``` elixir
AdtTest.AdtDefinition.case %AdtTest.AdtDefinition.Foo{}, [
  Foo: fn(x) -> "foo" end
]
```

```
** Not exhaustive!
    expanding macro: AdtTest.AdtDefinition.case/2
    test/adt_test.exs:68: AdtTest."test case"/1
    (elixir) lib/code.ex:363: Code.require_file/2
```

This needs to be cleaned up **a lot**! And the syntax needs some thinking through.
